### PR TITLE
Build project as UMD

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "types": "dist/sportlink-to-mailchimp-converter.d.ts",
   "type": "commonjs",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc --module umd",
     "lint": "eslint src",
-    "prepublish": "tsc",
+    "prepublish": "tsc --module umd",
     "test": "jest",
     "test:coverage": "jest --coverage=true --coverageDirectory=./coverage",
     "watch": "tsc --watch"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    "module": "umd",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */


### PR DESCRIPTION
Fixes #81

Update the build process to generate a Universal Module Definition (UMD) build.

* **package.json**
  - Update the `build` script to use `tsc --module umd`.
  - Update the `prepublish` script to use `tsc --module umd`.

* **tsconfig.json**
  - Change the `module` option to `umd`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/EdwinOtten/sportlink-to-mailchimp-converter/issues/81?shareId=12381a0c-ecb1-4e5c-b64a-e6be04e27577).