### PR TITLE
Publish only the dist directory

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -27,3 +27,4 @@ jobs:
       uses: JS-DevTools/npm-publish@v3
       with:
         token: ${{ secrets.NPM_AUTH_TOKEN }}
+        package: dist

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sportlink-to-mailchimp-converter",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A node module that converts Sportlink exports (.csv) into a csv you can import into Mailchimp.",
   "main": "dist/sportlink-to-mailchimp-converter.umd.js",
   "types": "dist/sportlink-to-mailchimp-converter.umd.d.ts",


### PR DESCRIPTION
Fixes #88

Update the `Publish to npm` step in the `npm-publish.yml` workflow to publish only the contents of the `dist` directory.

* Add `package: dist` to the `with` section of the `Publish to npm` step.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/EdwinOtten/sportlink-to-mailchimp-converter/issues/88?shareId=e157c421-aadc-42ee-8c8f-9f2f49cefc3d).