### PR TITLE
Fix npm-publish.yml workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -23,6 +23,9 @@ jobs:
     - name: Build
       run: npm run build
 
+    - name: Copy package.json to dist directory
+      run: cp package.json dist && sed -i 's/\"main\": \".*\"/\"main\": \"sportlink-to-mailchimp-converter.umd.js\"/' dist/package.json && sed -i 's/\"types\": \".*\"/\"types\": \"sportlink-to-mailchimp-converter.umd.d.ts\"/' dist/package.json
+
     - name: Publish to npm
       uses: JS-DevTools/npm-publish@v3
       with:


### PR DESCRIPTION
Fixes #87

Update `npm-publish.yml` workflow to correctly transpile and publish the application to NPM.

* Add a step to copy `package.json` to the `dist` directory before publishing.
* Modify the `main` and `types` properties in the copied `package.json` to point to the correct files.